### PR TITLE
Remove 'static const __m128' and ilk

### DIFF
--- a/include/sst/waveshapers/Fuzzes.h
+++ b/include/sst/waveshapers/Fuzzes.h
@@ -11,7 +11,7 @@ namespace sst::waveshapers
 template <int scale> float FuzzTable(const float x)
 {
     static auto gen = std::minstd_rand(2112);
-    static const float range = 0.1 * scale;
+    const float range = 0.1 * scale;
     static auto dist = std::uniform_real_distribution<float>(-range, range);
 
     auto xadj = x * (1 - range) + dist(gen);
@@ -28,7 +28,7 @@ __m128 Fuzz(QuadWaveshaperState *__restrict s, __m128 x, __m128 drive)
 inline float FuzzCtrTable(const float x)
 {
     static auto gen = std::minstd_rand(2112);
-    static const float b = 20;
+    const float b = 20;
 
     static auto dist = std::uniform_real_distribution<float>(-1.0, 1.0);
 

--- a/include/sst/waveshapers/Harmonics.h
+++ b/include/sst/waveshapers/Harmonics.h
@@ -10,8 +10,8 @@ namespace sst::waveshapers
 template <__m128 (*K)(__m128), bool useDCBlock>
 __m128 CHEBY_CORE(QuadWaveshaperState *__restrict s, __m128 x, __m128 drive)
 {
-    static const auto m1 = _mm_set1_ps(-1.0f);
-    static const auto p1 = _mm_set1_ps(1.0f);
+    const auto m1 = _mm_set1_ps(-1.0f);
+    const auto p1 = _mm_set1_ps(1.0f);
 
     auto bound = K(_mm_max_ps(_mm_min_ps(x, p1), m1));
 
@@ -24,15 +24,15 @@ __m128 CHEBY_CORE(QuadWaveshaperState *__restrict s, __m128 x, __m128 drive)
 
 inline __m128 cheb2_kernel(__m128 x) // 2 x^2 - 1
 {
-    static const auto m1 = _mm_set1_ps(1);
-    static const auto m2 = _mm_set1_ps(2);
+    const auto m1 = _mm_set1_ps(1);
+    const auto m2 = _mm_set1_ps(2);
     return _mm_sub_ps(_mm_mul_ps(m2, _mm_mul_ps(x, x)), m1);
 }
 
 inline __m128 cheb3_kernel(__m128 x) // 4 x^3 - 3 x
 {
-    static const auto m4 = _mm_set1_ps(4);
-    static const auto m3 = _mm_set1_ps(3);
+    const auto m4 = _mm_set1_ps(4);
+    const auto m3 = _mm_set1_ps(3);
     auto x2 = _mm_mul_ps(x, x);
     auto v4x2m3 = _mm_sub_ps(_mm_mul_ps(m4, x2), m3);
     return _mm_mul_ps(v4x2m3, x);
@@ -40,8 +40,8 @@ inline __m128 cheb3_kernel(__m128 x) // 4 x^3 - 3 x
 
 inline __m128 cheb4_kernel(__m128 x) // 8 x^4 - 8 x^2 + 1
 {
-    static const auto m1 = _mm_set1_ps(1);
-    static const auto m8 = _mm_set1_ps(8);
+    const auto m1 = _mm_set1_ps(1);
+    const auto m8 = _mm_set1_ps(8);
     auto x2 = _mm_mul_ps(x, x);
     auto x4mx2 = _mm_mul_ps(x2, _mm_sub_ps(x2, m1)); // x^2 * ( x^2 - 1)
     return _mm_add_ps(_mm_mul_ps(m8, x4mx2), m1);
@@ -49,9 +49,9 @@ inline __m128 cheb4_kernel(__m128 x) // 8 x^4 - 8 x^2 + 1
 
 inline __m128 cheb5_kernel(__m128 x) // 16 x^5 - 20 x^3 + 5 x
 {
-    static const auto m16 = _mm_set1_ps(16);
-    static const auto mn20 = _mm_set1_ps(-20);
-    static const auto m5 = _mm_set1_ps(5);
+    const auto m16 = _mm_set1_ps(16);
+    const auto mn20 = _mm_set1_ps(-20);
+    const auto m5 = _mm_set1_ps(5);
 
     auto x2 = _mm_mul_ps(x, x);
     auto x3 = _mm_mul_ps(x2, x);
@@ -65,32 +65,32 @@ inline __m128 cheb5_kernel(__m128 x) // 16 x^5 - 20 x^3 + 5 x
 // Implement sum_n w_i T_i
 template <int len> struct ChebSeries
 {
-    ChebSeries(const std::initializer_list<float> &f)
+    constexpr ChebSeries(const std::initializer_list<float> &f)
     {
         auto q = f.begin();
         auto idx = 0;
         for (int i = 0; i < len; ++i)
-            weights[i] = _mm_setzero_ps();
+            weights[i] = 0.f; // _mm_setzero_ps();
         while (idx < len && q != f.end())
         {
-            weights[idx] = _mm_set1_ps(*q);
+            weights[idx] = *q;
             ++idx;
             ++q;
         }
     }
-    __m128 weights[len];
+    float weights[len]{};
     __m128 eval(__m128 x) const // x bound on 0,1
     {
-        static const auto p2 = _mm_set1_ps(2.0);
+        const auto p2 = _mm_set1_ps(2.0);
         auto Tm1 = _mm_set1_ps(1.0);
         auto Tn = x;
-        auto res = _mm_add_ps(weights[0], _mm_mul_ps(weights[1], x));
+        auto res = _mm_add_ps(_mm_set1_ps(weights[0]), _mm_mul_ps(_mm_set1_ps(weights[1]), x));
         for (int idx = 2; idx < len; ++idx)
         {
             auto nxt = _mm_sub_ps(_mm_mul_ps(_mm_mul_ps(p2, Tn), x), Tm1);
             Tm1 = Tn;
             Tn = nxt;
-            res = _mm_add_ps(res, _mm_mul_ps(weights[idx], Tn));
+            res = _mm_add_ps(res, _mm_mul_ps(_mm_set1_ps(weights[idx]), Tn));
         }
         return res;
     }
@@ -98,52 +98,52 @@ template <int len> struct ChebSeries
 
 inline __m128 Plus12(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const auto ser = ChebSeries<3>({0, 0.5, 0.5});
-    static const auto scale = _mm_set1_ps(0.66);
+    static constexpr auto ser = ChebSeries<3>({0, 0.5, 0.5});
+    const auto scale = _mm_set1_ps(0.66);
     return dcBlock<0, 1>(s, ser.eval(TANH(s, _mm_mul_ps(in, scale), drive)));
 }
 
 inline __m128 Plus13(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const auto ser = ChebSeries<4>({0, 0.5, 0, 0.5});
-    static const auto scale = _mm_set1_ps(0.66);
+    static constexpr auto ser = ChebSeries<4>({0, 0.5, 0, 0.5});
+    const auto scale = _mm_set1_ps(0.66);
     return ser.eval(TANH(s, _mm_mul_ps(in, scale), drive));
 }
 
 inline __m128 Plus14(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const auto ser = ChebSeries<5>({0, 0.5, 0, 0, 0.5});
-    static const auto scale = _mm_set1_ps(0.66);
+    static constexpr auto ser = ChebSeries<5>({0, 0.5, 0, 0, 0.5});
+    const auto scale = _mm_set1_ps(0.66);
     return dcBlock<0, 1>(s, ser.eval(TANH(s, _mm_mul_ps(in, scale), drive)));
 }
 
 inline __m128 Plus15(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const auto ser = ChebSeries<6>({0, 0.5, 0, 0, 0, 0.5});
-    static const auto scale = _mm_set1_ps(0.66);
+    static constexpr auto ser = ChebSeries<6>({0, 0.5, 0, 0, 0, 0.5});
+    const auto scale = _mm_set1_ps(0.66);
     return ser.eval(TANH(s, _mm_mul_ps(in, scale), drive));
 }
 
 inline __m128 Plus12345(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const auto ser = ChebSeries<6>({0, 0.2, 0.2, 0.2, 0.2, 0.2});
-    static const auto scale = _mm_set1_ps(0.66);
+    static constexpr auto ser = ChebSeries<6>({0, 0.2, 0.2, 0.2, 0.2, 0.2});
+    const auto scale = _mm_set1_ps(0.66);
     return dcBlock<0, 1>(s, ser.eval(TANH(s, _mm_mul_ps(in, scale), drive)));
 }
 
 inline __m128 PlusSaw3(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const float fac = 0.9f / (1.f + 0.5 + 0.25);
-    static const auto ser = ChebSeries<4>({0, -fac, fac * 0.5f, -fac * 0.25f});
-    static const auto scale = _mm_set1_ps(-0.66); // flip direction
+    static constexpr float fac = 0.9f / (1.f + 0.5 + 0.25);
+    static constexpr auto ser = ChebSeries<4>({0, -fac, fac * 0.5f, -fac * 0.25f});
+    const auto scale = _mm_set1_ps(-0.66); // flip direction
     return dcBlock<0, 1>(s, ser.eval(TANH(s, _mm_mul_ps(in, scale), drive)));
 }
 
 inline __m128 PlusSqr3(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
-    static const float fac = 0.9f / (1.f - 0.25 + 1.0 / 16.0);
-    static const auto ser = ChebSeries<6>({0, fac, 0, -fac * 0.25f, 0, fac / 16.f});
-    static const auto scale = _mm_set1_ps(0.66);
+    static constexpr float fac = 0.9f / (1.f - 0.25 + 1.0 / 16.0);
+    static constexpr auto ser = ChebSeries<6>({0, fac, 0, -fac * 0.25f, 0, fac / 16.f});
+    const auto scale = _mm_set1_ps(0.66);
     return ser.eval(TANH(s, _mm_mul_ps(in, scale), drive));
 }
 

--- a/include/sst/waveshapers/Rectifiers.h
+++ b/include/sst/waveshapers/Rectifiers.h
@@ -16,7 +16,7 @@ inline void posrect_kernel(__m128 x, __m128 &f, __m128 &adF)
      *
      * observe that adF = F^2/2 in all cases
      */
-    static const auto p5 = _mm_set1_ps(0.5f);
+    const auto p5 = _mm_set1_ps(0.5f);
     auto gz = _mm_cmpge_ps(x, _mm_setzero_ps());
     f = _mm_and_ps(gz, x);
     adF = _mm_mul_ps(p5, _mm_mul_ps(f, f));
@@ -37,7 +37,7 @@ inline void negrect_kernel(__m128 x, __m128 &f, __m128 &adF)
      *
      * observe that adF = F^2/2 in all cases
      */
-    static const auto p5 = _mm_set1_ps(0.5f);
+    const auto p5 = _mm_set1_ps(0.5f);
     auto gz = _mm_cmple_ps(x, _mm_setzero_ps());
     f = _mm_and_ps(gz, x);
     adF = _mm_mul_ps(p5, _mm_mul_ps(f, f));
@@ -56,8 +56,8 @@ inline void fwrect_kernel(__m128 x, __m128 &F, __m128 &adF)
      * F   : x > 0 ? x : -x  = sgn(x) * x
      * adF : x > 0 ? x^2 / 2 : -x^2 / 2 = sgn(x) * x^2 / 2
      */
-    static const auto p1 = _mm_set1_ps(1.f);
-    static const auto p05 = _mm_set1_ps(0.5f);
+    const auto p1 = _mm_set1_ps(1.f);
+    const auto p05 = _mm_set1_ps(0.5f);
     auto gz = _mm_cmpge_ps(x, _mm_setzero_ps());
     auto sgn = _mm_sub_ps(_mm_and_ps(gz, p1), _mm_andnot_ps(gz, p1));
 
@@ -77,8 +77,8 @@ inline void softrect_kernel(__m128 x, __m128 &F, __m128 &adF)
      * F   : x > 0 ? 2x-1 : -2x - 1   = 2 * ( sgn(x) * x ) - 1
      * adF : x > 0 ? x^2-x : -x^2 - x = sgn(x) * x^2 - x
      */
-    static const auto p2 = _mm_set1_ps(2.f);
-    static const auto p1 = _mm_set1_ps(1.f);
+    const auto p2 = _mm_set1_ps(2.f);
+    const auto p1 = _mm_set1_ps(1.f);
     auto gz = _mm_cmpge_ps(x, _mm_setzero_ps());
     auto sgn = _mm_sub_ps(_mm_and_ps(gz, p1), _mm_andnot_ps(gz, p1));
 

--- a/include/sst/waveshapers/Saturators.h
+++ b/include/sst/waveshapers/Saturators.h
@@ -38,8 +38,8 @@ inline __m128 ZAMSAT(QuadWaveshaperState *__restrict s, __m128 x, __m128 drive)
     x = CLIP(s, x, drive);
 
     // 2x * ( 1 - |x| )
-    static const auto p1 = _mm_set1_ps(1.f);
-    static const auto p2 = _mm_set1_ps(2.f);
+    const auto p1 = _mm_set1_ps(1.f);
+    const auto p2 = _mm_set1_ps(2.f);
 
     auto gz = _mm_cmpge_ps(x, _mm_setzero_ps());
     auto sgn = _mm_sub_ps(_mm_and_ps(gz, p1), _mm_andnot_ps(gz, p1));
@@ -60,13 +60,13 @@ inline __m128 OJD(QuadWaveshaperState *__restrict s, __m128 x, __m128 drive)
 {
     x = _mm_mul_ps(x, drive);
 
-    static const auto pm17 = _mm_set1_ps(-1.7f);
-    static const auto p11 = _mm_set1_ps(1.1f);
-    static const auto pm03 = _mm_set1_ps(-0.3f);
-    static const auto p09 = _mm_set1_ps(0.9f);
+    const auto pm17 = _mm_set1_ps(-1.7f);
+    const auto p11 = _mm_set1_ps(1.1f);
+    const auto pm03 = _mm_set1_ps(-0.3f);
+    const auto p09 = _mm_set1_ps(0.9f);
 
-    static const auto denLow = _mm_set1_ps(1.f / (4 * (1 - 0.3f)));
-    static const auto denHigh = _mm_set1_ps(1.f / (4 * (1 - 0.9f)));
+    const auto denLow = _mm_set1_ps(1.f / (4 * (1 - 0.3f)));
+    const auto denHigh = _mm_set1_ps(1.f / (4 * (1 - 0.9f)));
 
     auto maskNeg = _mm_cmple_ps(x, pm17);                         // in <= -1.7f
     auto maskPos = _mm_cmpge_ps(x, p11);                          // in > 1.1f
@@ -74,8 +74,8 @@ inline __m128 OJD(QuadWaveshaperState *__restrict s, __m128 x, __m128 drive)
     auto maskHigh = _mm_andnot_ps(maskPos, _mm_cmpgt_ps(x, p09)); // in > 0.9 && in < 1.1
     auto maskMid = _mm_and_ps(_mm_cmpge_ps(x, pm03), _mm_cmple_ps(x, p09)); // the middle
 
-    static const auto vNeg = _mm_set1_ps(-1.0);
-    static const auto vPos = _mm_set1_ps(1.0);
+    const auto vNeg = _mm_set1_ps(-1.0);
+    const auto vPos = _mm_set1_ps(1.0);
     auto vMid = x;
 
     auto xlow = _mm_sub_ps(x, pm03);

--- a/include/sst/waveshapers/Wavefolders.h
+++ b/include/sst/waveshapers/Wavefolders.h
@@ -45,7 +45,7 @@ template <int pts> struct FolderADAA
 
     inline void evaluate(__m128 x, __m128 &f, __m128 &adf)
     {
-        static const auto p05 = _mm_set1_ps(0.5f);
+        const auto p05 = _mm_set1_ps(0.5f);
         __m128 rangeMask[pts - 1], val[pts - 1], adVal[pts - 1];
 
         for (int i = 0; i < pts - 1; ++i)
@@ -118,8 +118,8 @@ inline __m128 SoftOneFold(QuadWaveshaperState *__restrict, __m128 x, __m128 driv
     auto y = _mm_mul_ps(x, drive);
     auto y2 = _mm_mul_ps(y, y);
 
-    static const auto p04 = _mm_set1_ps(0.4f);
-    static const auto p07 = _mm_set1_ps(0.7f);
+    const auto p04 = _mm_set1_ps(0.4f);
+    const auto p07 = _mm_set1_ps(0.7f);
 
     auto num = _mm_add_ps(p04, _mm_mul_ps(p07, y2));
 

--- a/include/sst/waveshapers/WaveshaperLUT.h
+++ b/include/sst/waveshapers/WaveshaperLUT.h
@@ -56,12 +56,12 @@ __m128 WS_LUT(QuadWaveshaperState *__restrict, const float *table, __m128 in, __
 // Given a table of size N+1, N a power of 2, representing data between -1 and 1, interp
 template <int N> __m128 WS_PM1_LUT(const float *table, __m128 in)
 {
-    static const __m128 one = _mm_set1_ps(1.f);
-    static const __m128 dx = _mm_set1_ps(N / 2.f);
-    static const __m128 oodx = _mm_set1_ps(2.f / N);
-    static const __m128 ctr = _mm_set1_ps(N / 2.f);
-    static const __m128 UB = _mm_set1_ps(N - 1.f);
-    static const __m128 zero = _mm_setzero_ps();
+    const auto one = _mm_set1_ps(1.f);
+    const auto dx = _mm_set1_ps(N / 2.f);
+    const auto oodx = _mm_set1_ps(2.f / N);
+    const auto ctr = _mm_set1_ps(N / 2.f);
+    const auto UB = _mm_set1_ps(N - 1.f);
+    const auto zero = _mm_setzero_ps();
 
     auto x = _mm_add_ps(_mm_mul_ps(in, dx), ctr);
     auto e = _mm_cvtps_epi32(_mm_max_ps(_mm_min_ps(x, UB), zero));


### PR DESCRIPTION
As discussed in https://github.com/surge-synthesizer/surge/issues/6510
this idiom is just wrong. mostly jsut replace with static, but for the
ChebSer make a shuffle so the constructor is constepxr instead.