### PR TITLE
Add Linear and Sine folds from Vital Synth

### DIFF
--- a/include/sst/waveshapers/Effects.h
+++ b/include/sst/waveshapers/Effects.h
@@ -19,20 +19,37 @@ inline __m128 DIGI_SSE2(QuadWaveshaperState *__restrict, __m128 in, __m128 drive
     return _mm_mul_ps(drive, _mm_mul_ps(m16inv, _mm_sub_ps(_mm_cvtepi32_ps(a), mofs)));
 }
 
+template<bool DO_FOLD = false>
 inline __m128 SINUS_SSE2(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
     const __m128 one = _mm_set1_ps(1.f);
     const __m128 m256 = _mm_set1_ps(256.f);
     const __m128 m512 = _mm_set1_ps(512.f);
 
+    // Scale so that -1.0 - 1.0 goes to 256 - 768
+    // +6 dB gets you the full sine wave
     __m128 x = _mm_mul_ps(in, drive);
     x = _mm_add_ps(_mm_mul_ps(x, m256), m512);
 
+    // Convert to 32 bit ints
     __m128i e = _mm_cvtps_epi32(x);
+    // Calculate the remainder due to truncation. This is used for later interpolation
     __m128 a = _mm_sub_ps(x, _mm_cvtepi32_ps(e));
-    e = _mm_packs_epi32(e, e);
-    const __m128i UB = _mm_set1_epi16(0x3fe);
-    e = _mm_max_epi16(_mm_min_epi16(e, UB), _mm_setzero_si128());
+
+    // Template arg -- Compiler will optimize this out
+    if (DO_FOLD) {
+        // Now, make sure the fold pattern repeats
+        // Fortunately, we're dealing with a power-of-two LUT so we can do a modulus by bitwise and like so:
+        e = _mm_and_si128(e, _mm_set1_epi32(0x3ff));
+        // Now pack into 16 bit ints. Should already be truncated
+        // If not, whoops, segfault
+        e = _mm_packs_epi32(e, e);
+    } else {
+        // Don't repeat; Instead, clip to zero at the boundaries
+        e = _mm_packs_epi32(e, e);
+        const __m128i UB = _mm_set1_epi16(0x3fe);
+        e = _mm_max_epi16(_mm_min_epi16(e, UB), _mm_setzero_si128());
+    }
 
 #if MAC
     // this should be very fast on C2D/C1D (and there are no macs with K8's)

--- a/include/sst/waveshapers/Effects.h
+++ b/include/sst/waveshapers/Effects.h
@@ -19,7 +19,7 @@ inline __m128 DIGI_SSE2(QuadWaveshaperState *__restrict, __m128 in, __m128 drive
     return _mm_mul_ps(drive, _mm_mul_ps(m16inv, _mm_sub_ps(_mm_cvtepi32_ps(a), mofs)));
 }
 
-template<bool DO_FOLD = false>
+template <bool DO_FOLD = false>
 inline __m128 SINUS_SSE2(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
 {
     const __m128 one = _mm_set1_ps(1.f);
@@ -37,14 +37,18 @@ inline __m128 SINUS_SSE2(QuadWaveshaperState *__restrict s, __m128 in, __m128 dr
     __m128 a = _mm_sub_ps(x, _mm_cvtepi32_ps(e));
 
     // Template arg -- Compiler will optimize this out
-    if (DO_FOLD) {
+    if (DO_FOLD)
+    {
         // Now, make sure the fold pattern repeats
-        // Fortunately, we're dealing with a power-of-two LUT so we can do a modulus by bitwise and like so:
+        // Fortunately, we're dealing with a power-of-two LUT so we can do a modulus by bitwise and
+        // like so:
         e = _mm_and_si128(e, _mm_set1_epi32(0x3ff));
         // Now pack into 16 bit ints. Should already be truncated
         // If not, whoops, segfault
         e = _mm_packs_epi32(e, e);
-    } else {
+    }
+    else
+    {
         // Don't repeat; Instead, clip to zero at the boundaries
         e = _mm_packs_epi32(e, e);
         const __m128i UB = _mm_set1_epi16(0x3fe);

--- a/include/sst/waveshapers/QuadWaveshaper_Impl.h
+++ b/include/sst/waveshapers/QuadWaveshaper_Impl.h
@@ -32,7 +32,7 @@ inline QuadWaveshaperPtr GetQuadWaveshaper(WaveshaperType type)
 
     // effects
     case WaveshaperType::wst_sine:
-        return SINUS_SSE2;
+        return SINUS_SSE2<false>;
     case WaveshaperType::wst_digital:
         return DIGI_SSE2;
 
@@ -82,7 +82,7 @@ inline QuadWaveshaperPtr GetQuadWaveshaper(WaveshaperType type)
     case WaveshaperType::wst_linearfold:
         return LINFOLD_SSE2;
     case WaveshaperType::wst_sinefold:
-        return SINEFOLD_SSE2;
+        return SINUS_SSE2<true>;
 
     // fuzzes
     case WaveshaperType::wst_fuzz:

--- a/include/sst/waveshapers/QuadWaveshaper_Impl.h
+++ b/include/sst/waveshapers/QuadWaveshaper_Impl.h
@@ -79,6 +79,10 @@ inline QuadWaveshaperPtr GetQuadWaveshaper(WaveshaperType type)
         return WAVEFOLDER<dualFoldADAA>;
     case WaveshaperType::wst_westfold:
         return WAVEFOLDER<westCoastFoldADAA>;
+    case WaveshaperType::wst_linearfold:
+        return LINFOLD_SSE2;
+    case WaveshaperType::wst_sinefold:
+        return SINEFOLD_SSE2;
 
     // fuzzes
     case WaveshaperType::wst_fuzz:

--- a/include/sst/waveshapers/Wavefolders.h
+++ b/include/sst/waveshapers/Wavefolders.h
@@ -162,61 +162,8 @@ inline __m128 LINFOLD_SSE2(QuadWaveshaperState *__restrict s, __m128 in, __m128 
     return a;
 }
 
-inline __m128 SINEFOLD_SSE2(QuadWaveshaperState *__restrict s, __m128 in, __m128 drive)
-{
-    // This code starts with a custom bit to make it fold, then is just a copy of SINUS_SSE2
-    const __m128 one = _mm_set1_ps(1.f);
-    const __m128 m256 = _mm_set1_ps(256.f);
-    const __m128 m512 = _mm_set1_ps(512.f);
+// Sine fold is implemented in SINUS_SSE2 in Effects.h via template args
 
-    // Scale so that -1.0 - 1.0 goes to 256 - 768
-    // +6 dB gets you the full sine wave
-    __m128 x = _mm_mul_ps(in, drive);
-    x = _mm_add_ps(_mm_mul_ps(x, m256), m512);
-
-    // Convert to 32 bit ints
-    __m128i e = _mm_cvtps_epi32(x);
-    // Calculate the remainder due to truncation. This is used for later interpolation
-    __m128 a = _mm_sub_ps(x, _mm_cvtepi32_ps(e));
-    // Now, make sure the fold pattern repeats
-    // Fortunately, we're dealing with a power-of-two LUT so we can do a modulus by bitwise and like so:
-    e = _mm_and_si128(e, _mm_set1_epi32(0x3ff));
-    // Now pack into 16 bit ints. Should already be truncated
-    // If not, whoops, segfault
-    e = _mm_packs_epi32(e, e);
-
-    // And the rest of this is just copied from SINUS
-#if MAC
-    // this should be very fast on C2D/C1D (and there are no macs with K8's)
-    // GCC seems to optimize around the XMM -> int transfers so this is needed here
-    int e4 alignas(16)[4];
-    e4[0] = _mm_cvtsi128_si32(e);
-    e4[1] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(1, 1, 1, 1)));
-    e4[2] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(2, 2, 2, 2)));
-    e4[3] = _mm_cvtsi128_si32(_mm_shufflelo_epi16(e, _MM_SHUFFLE(3, 3, 3, 3)));
-#else
-    // on PC write to memory & back as XMM -> GPR is slow on K8
-    short e4 alignas(16)[8];
-    _mm_store_si128((__m128i *)&e4, e);
-#endif
-
-    const auto &table =
-        globalWaveshaperTables.waveshapers[static_cast<int>(WaveshaperType::wst_sine)];
-    __m128 ws1 = _mm_load_ss(&table[e4[0] & 0x3ff]);
-    __m128 ws2 = _mm_load_ss(&table[e4[1] & 0x3ff]);
-    __m128 ws3 = _mm_load_ss(&table[e4[2] & 0x3ff]);
-    __m128 ws4 = _mm_load_ss(&table[e4[3] & 0x3ff]);
-    __m128 ws = _mm_movelh_ps(_mm_unpacklo_ps(ws1, ws2), _mm_unpacklo_ps(ws3, ws4));
-    ws1 = _mm_load_ss(&table[(e4[0] + 1) & 0x3ff]);
-    ws2 = _mm_load_ss(&table[(e4[1] + 1) & 0x3ff]);
-    ws3 = _mm_load_ss(&table[(e4[2] + 1) & 0x3ff]);
-    ws4 = _mm_load_ss(&table[(e4[3] + 1) & 0x3ff]);
-    __m128 wsn = _mm_movelh_ps(_mm_unpacklo_ps(ws1, ws2), _mm_unpacklo_ps(ws3, ws4));
-
-    x = _mm_add_ps(_mm_mul_ps(_mm_sub_ps(one, a), ws), _mm_mul_ps(a, wsn));
-
-    return x;
-}
 } // namespace sst::waveshapers
 
 #endif // SST_WAVESHAPERS_WAVEFOLDERS_H

--- a/include/sst/waveshapers/Wavefolders.h
+++ b/include/sst/waveshapers/Wavefolders.h
@@ -151,10 +151,10 @@ inline __m128 LINFOLD_SSE2(QuadWaveshaperState *__restrict s, __m128 in, __m128 
     // Finally, scale the output value
     a = _mm_mul_ps(a, mfour);
     a = _mm_add_ps(a, two);
-    
+
     // Absolute value
     uint32_t v = 0x7fffffff; // Trick C++ into initializing a float mask that clears the sign bit
-    a = _mm_and_ps(a, _mm_set1_ps(*((float*)&v)));
+    a = _mm_and_ps(a, _mm_set1_ps(*((float *)&v)));
 
     // Now finish up by shifting down a bit...
     a = _mm_sub_ps(a, one);

--- a/include/sst/waveshapers/WaveshaperConfiguration.h
+++ b/include/sst/waveshapers/WaveshaperConfiguration.h
@@ -76,6 +76,7 @@ const char wst_names[(int)WaveshaperType::n_ws_types][32] = {"Off",
                                                              "Asymmetric",
                                                              "Sine",
                                                              "Digital",
+                                                             
                                                              "Soft Harmonic 2",
                                                              "Soft Harmonic 3",
                                                              "Soft Harmonic 4",
@@ -87,6 +88,9 @@ const char wst_names[(int)WaveshaperType::n_ws_types][32] = {"Off",
                                                              "Single Fold",
                                                              "Double Fold",
                                                              "West Coast Fold",
+                                                             "Linear Fold",
+                                                             "Sine Fold",
+
                                                              "Additive 1+2",
                                                              "Additive 1+3",
                                                              "Additive 1+4",
@@ -160,6 +164,8 @@ inline std::vector<std::pair<int, std::string>> WaveshaperGroupName()
         p(sst::waveshapers::WaveshaperType::wst_singlefold, "Wavefolder");
         p(sst::waveshapers::WaveshaperType::wst_dualfold, "Wavefolder");
         p(sst::waveshapers::WaveshaperType::wst_westfold, "Wavefolder");
+        p(sst::waveshapers::WaveshaperType::wst_linearfold, "Wavefolder");
+        p(sst::waveshapers::WaveshaperType::wst_sinefold, "Wavefolder");
 
         p(sst::waveshapers::WaveshaperType::wst_fuzz, "Fuzz");
         p(sst::waveshapers::WaveshaperType::wst_fuzzheavy, "Fuzz");

--- a/include/sst/waveshapers/WaveshaperConfiguration.h
+++ b/include/sst/waveshapers/WaveshaperConfiguration.h
@@ -7,6 +7,8 @@
 namespace sst::waveshapers
 {
 
+// Since these are streamed in some properties, please only add items to the end
+// Grouping and ordering in uis happens via the groupname below not the order here
 enum class WaveshaperType
 {
     wst_none = 0,
@@ -30,8 +32,6 @@ enum class WaveshaperType
     wst_singlefold,
     wst_dualfold,
     wst_westfold,
-    wst_linearfold,
-    wst_sinefold,
 
     // additive harmonics
     wst_add12,
@@ -67,58 +67,63 @@ enum class WaveshaperType
 
     wst_softfold,
 
+    wst_linearfold,
+    wst_sinefold,
+
     n_ws_types,
 };
 
-const char wst_names[(int)WaveshaperType::n_ws_types][32] = {"Off",
-                                                             "Soft",
-                                                             "Hard",
-                                                             "Asymmetric",
-                                                             "Sine",
-                                                             "Digital",
-                                                             
-                                                             "Soft Harmonic 2",
-                                                             "Soft Harmonic 3",
-                                                             "Soft Harmonic 4",
-                                                             "Soft Harmonic 5",
-                                                             "Full Wave",
-                                                             "Half Wave Positive",
-                                                             "Half Wave Negative",
-                                                             "Soft Rectifier",
-                                                             "Single Fold",
-                                                             "Double Fold",
-                                                             "West Coast Fold",
-                                                             "Linear Fold",
-                                                             "Sine Fold",
+const char wst_names[(int)WaveshaperType::n_ws_types][32] = {
+    "Off",
+    "Soft",
+    "Hard",
+    "Asymmetric",
+    "Sine",
+    "Digital",
 
-                                                             "Additive 1+2",
-                                                             "Additive 1+3",
-                                                             "Additive 1+4",
-                                                             "Additive 1+5",
-                                                             "Additive 12345",
-                                                             "Additive Saw 3",
-                                                             "Additive Square 3",
+    "Soft Harmonic 2",
+    "Soft Harmonic 3",
+    "Soft Harmonic 4",
+    "Soft Harmonic 5",
+    "Full Wave",
+    "Half Wave Positive",
+    "Half Wave Negative",
+    "Soft Rectifier",
+    "Single Fold",
+    "Double Fold",
+    "West Coast Fold",
 
-                                                             "Fuzz",
-                                                             "Fuzz Soft Clip",
-                                                             "Heavy Fuzz",
-                                                             "Fuzz Center",
-                                                             "Fuzz Soft Edge",
+    "Additive 1+2",
+    "Additive 1+3",
+    "Additive 1+4",
+    "Additive 1+5",
+    "Additive 12345",
+    "Additive Saw 3",
+    "Additive Square 3",
 
-                                                             "Sin+x",
-                                                             "Sin 2x + x",
-                                                             "Sin 3x + x",
-                                                             "Sin 7x + x",
-                                                             "Sin 10x + x",
-                                                             "2 Cycle",
-                                                             "7 Cycle",
-                                                             "10 Cycle",
-                                                             "2 Cycle Bound",
-                                                             "7 Cycle Bound",
-                                                             "10 Cycle Bound",
-                                                             "Medium",
-                                                             "OJD",
-                                                             "Soft Single Fold"};
+    "Fuzz",
+    "Fuzz Soft Clip",
+    "Heavy Fuzz",
+    "Fuzz Center",
+    "Fuzz Soft Edge",
+
+    "Sin+x",
+    "Sin 2x + x",
+    "Sin 3x + x",
+    "Sin 7x + x",
+    "Sin 10x + x",
+    "2 Cycle",
+    "7 Cycle",
+    "10 Cycle",
+    "2 Cycle Bound",
+    "7 Cycle Bound",
+    "10 Cycle Bound",
+    "Medium",
+    "OJD",
+    "Soft Single Fold",
+    "Linear Fold",
+    "Sine Fold",
+};
 
 inline std::vector<std::pair<int, std::string>> WaveshaperGroupName()
 {

--- a/include/sst/waveshapers/WaveshaperConfiguration.h
+++ b/include/sst/waveshapers/WaveshaperConfiguration.h
@@ -30,6 +30,8 @@ enum class WaveshaperType
     wst_singlefold,
     wst_dualfold,
     wst_westfold,
+    wst_linearfold,
+    wst_sinefold,
 
     // additive harmonics
     wst_add12,


### PR DESCRIPTION
Adds the Linear and Sine folds using similar techniques as those used in the [Vital](https://github.com/mtytel/vital) synthesizer (GPLv2). They look like this (picture taken from my Vitality fork, drive set to ~10.5 dB):

![Linear Fold](https://github.com/user-attachments/assets/afd3156b-e6bd-4646-a2ae-bdd24d385920)

![image](https://github.com/user-attachments/assets/6a65cf9e-8b35-475b-9928-cc6656ab425b)

This was originally developed for use in my Vitality project (WIP), where I replaced vital's distorts with the SST ones.