### PR TITLE
Fix the click-at-outset

### DIFF
--- a/include/sst/waveshapers/DCBlocker.h
+++ b/include/sst/waveshapers/DCBlocker.h
@@ -18,7 +18,8 @@
 
 namespace sst::waveshapers
 {
-template <int R1, int R2> inline SIMD_M128 dcBlock(QuadWaveshaperState *__restrict s, SIMD_M128 x)
+template <int R1, int R2, bool updateInit = true>
+inline SIMD_M128 dcBlock(QuadWaveshaperState *__restrict s, SIMD_M128 x)
 {
     // https://www.dsprelated.com/freebooks/filters/DC_Blocker.html
     // y_n = x_n - x_n-1 + R y_n-1
@@ -31,7 +32,10 @@ template <int R1, int R2> inline SIMD_M128 dcBlock(QuadWaveshaperState *__restri
 
     s->R[R1] = x;
     s->R[R2] = filtval;
-    s->init = SIMD_MM(setzero_ps)();
+    if (updateInit)
+    {
+        s->init = SIMD_MM(setzero_ps)();
+    }
     return filtval;
 }
 } // namespace sst::waveshapers

--- a/include/sst/waveshapers/DCBlocker.h
+++ b/include/sst/waveshapers/DCBlocker.h
@@ -24,7 +24,11 @@ template <int R1, int R2> inline SIMD_M128 dcBlock(QuadWaveshaperState *__restri
     // y_n = x_n - x_n-1 + R y_n-1
     const auto fac = SIMD_MM(set1_ps)(0.9999);
     auto dx = SIMD_MM(sub_ps)(x, s->R[R1]);
+    dx = SIMD_MM(add_ps)(SIMD_MM(and_ps)(s->init, SIMD_MM(setzero_ps)()),
+                         SIMD_MM(andnot_ps)(s->init, dx));
+
     auto filtval = SIMD_MM(add_ps)(dx, SIMD_MM(mul_ps)(fac, s->R[R2]));
+
     s->R[R1] = x;
     s->R[R2] = filtval;
     s->init = SIMD_MM(setzero_ps)();

--- a/include/sst/waveshapers/QuadWaveshaper_Impl.h
+++ b/include/sst/waveshapers/QuadWaveshaper_Impl.h
@@ -146,16 +146,56 @@ inline QuadWaveshaperPtr GetQuadWaveshaper(WaveshaperType type)
 
 inline void initializeWaveshaperRegister(WaveshaperType type, float R[n_waveshaper_registers])
 {
+    for (int i = 0; i < n_waveshaper_registers; ++i)
+        R[i] = 0.f;
+
+    // These are basically setting up the DC blcker so the value of 'prior observation'
+    // is what the DC blocker is fed at zero
     switch (type)
     {
-    default:
+    case WaveshaperType::wst_add12:
+        R[0] = -0.5f;
+        break;
+    case WaveshaperType::wst_add14:
+        R[0] = 0.5f;
+        break;
+    case WaveshaperType::wst_addsaw3:
+        R[0] = -0.257143;
+        break;
+    case WaveshaperType::wst_softrect:
+        R[2] = -1;
+        break;
+    case WaveshaperType::wst_cheby2:
+        R[0] = -1;
+        break;
+    case WaveshaperType::wst_cheby4:
+        R[0] = 1;
+        break;
+    case WaveshaperType::wst_fuzz:
+    case WaveshaperType::wst_fuzzsoft:
     {
-        for (int i = 0; i < n_waveshaper_registers; ++i)
-            R[i] = 0.f;
+        auto dat = LutTableData<FuzzTable<1>, 1024>();
+        auto ctr = dat[512];
+        R[0] = ctr;
     }
     break;
+    case WaveshaperType::wst_fuzzheavy:
+    {
+        auto dat = LutTableData<FuzzTable<3>, 1024>();
+        auto ctr = dat[512];
+        R[0] = ctr;
     }
-    return;
+    break;
+    case WaveshaperType::wst_fuzzctr:
+    {
+        auto dat = LutTableData<FuzzCtrTable, 2048>();
+        auto ctr = dat[1024];
+        R[0] = ctr;
+    }
+    break;
+    default:
+        break;
+    }
 }
 } // namespace sst::waveshapers
 

--- a/include/sst/waveshapers/QuadWaveshaper_Impl.h
+++ b/include/sst/waveshapers/QuadWaveshaper_Impl.h
@@ -148,7 +148,7 @@ inline void initializeWaveshaperRegister(WaveshaperType type, float R[n_waveshap
 {
     for (int i = 0; i < n_waveshaper_registers; ++i)
         R[i] = 0.f;
-
+#if 0
     // These are basically setting up the DC blcker so the value of 'prior observation'
     // is what the DC blocker is fed at zero
     switch (type)
@@ -171,31 +171,10 @@ inline void initializeWaveshaperRegister(WaveshaperType type, float R[n_waveshap
     case WaveshaperType::wst_cheby4:
         R[0] = 1;
         break;
-    case WaveshaperType::wst_fuzz:
-    case WaveshaperType::wst_fuzzsoft:
-    {
-        auto dat = LutTableData<FuzzTable<1>, 1024>();
-        auto ctr = dat[512];
-        R[0] = ctr;
-    }
-    break;
-    case WaveshaperType::wst_fuzzheavy:
-    {
-        auto dat = LutTableData<FuzzTable<3>, 1024>();
-        auto ctr = dat[512];
-        R[0] = ctr;
-    }
-    break;
-    case WaveshaperType::wst_fuzzctr:
-    {
-        auto dat = LutTableData<FuzzCtrTable, 2048>();
-        auto ctr = dat[1024];
-        R[0] = ctr;
-    }
-    break;
     default:
         break;
     }
+#endif
 }
 } // namespace sst::waveshapers
 

--- a/include/sst/waveshapers/QuadWaveshaper_Impl.h
+++ b/include/sst/waveshapers/QuadWaveshaper_Impl.h
@@ -146,35 +146,16 @@ inline QuadWaveshaperPtr GetQuadWaveshaper(WaveshaperType type)
 
 inline void initializeWaveshaperRegister(WaveshaperType type, float R[n_waveshaper_registers])
 {
-    for (int i = 0; i < n_waveshaper_registers; ++i)
-        R[i] = 0.f;
-#if 0
-    // These are basically setting up the DC blcker so the value of 'prior observation'
-    // is what the DC blocker is fed at zero
     switch (type)
     {
-    case WaveshaperType::wst_add12:
-        R[0] = -0.5f;
-        break;
-    case WaveshaperType::wst_add14:
-        R[0] = 0.5f;
-        break;
-    case WaveshaperType::wst_addsaw3:
-        R[0] = -0.257143;
-        break;
-    case WaveshaperType::wst_softrect:
-        R[2] = -1;
-        break;
-    case WaveshaperType::wst_cheby2:
-        R[0] = -1;
-        break;
-    case WaveshaperType::wst_cheby4:
-        R[0] = 1;
-        break;
     default:
-        break;
+    {
+        for (int i = 0; i < n_waveshaper_registers; ++i)
+            R[i] = 0.f;
     }
-#endif
+    break;
+    }
+    return;
 }
 } // namespace sst::waveshapers
 

--- a/include/sst/waveshapers/WaveshaperLUT.h
+++ b/include/sst/waveshapers/WaveshaperLUT.h
@@ -118,15 +118,21 @@ template <int NP, float F(const float)> struct LUTBase
     }
 };
 
+template <float F(float), int N> inline float *LutTableData()
+{
+    static LUTBase<N, F> table;
+    return table.data;
+}
+
 template <float F(float), int N, SIMD_M128 C(QuadWaveshaperState *__restrict, SIMD_M128, SIMD_M128),
           bool block = true>
 SIMD_M128 TableEval(QuadWaveshaperState *__restrict s, SIMD_M128 x, SIMD_M128 drive)
 {
-    static LUTBase<N, F> table;
+    auto data = LutTableData<F, N>();
     if (block)
-        return dcBlock<0, 1>(s, WS_PM1_LUT<N>(table.data, C(s, x, drive)));
+        return dcBlock<0, 1>(s, WS_PM1_LUT<N>(data, C(s, x, drive)));
     else
-        return WS_PM1_LUT<N>(table.data, C(s, x, drive));
+        return WS_PM1_LUT<N>(data, C(s, x, drive));
 }
 } // namespace sst::waveshapers
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(sst-waveshapers-tests
         FuzzesTest.cpp
         TrigonometricsTest.cpp
         ShapesAreBounded.cpp
+        ClickAtOutset.cpp
         tests.cpp
 )
 

--- a/tests/ClickAtOutset.cpp
+++ b/tests/ClickAtOutset.cpp
@@ -1,0 +1,71 @@
+/*
+ * sst-waveshaper - an open source library of waveshaper algorithms
+ * by the Surge Synth Team
+ *
+ * Copyright 2018-2025, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-jucegui is released under the GNU General Public License 3 or later
+ * as found in LICENSE.md in this repository.
+ *
+ * All source in sst-waveshapers available at
+ * https://github.com/surge-synthesizer/sst-waveshapers
+ */
+
+#include "TestUtils.h"
+#include <iostream>
+#include "sst/basic-blocks/simd/setup.h"
+#include "sst/waveshapers.h"
+#include <cmath>
+#include <vector>
+#include <random>
+#include <algorithm>
+
+TEST_CASE("Click At Outset")
+{
+    for (int shindex = 1; shindex < (int)sst::waveshapers::WaveshaperType::n_ws_types; ++shindex)
+    {
+        if (shindex == (int)sst::waveshapers::WaveshaperType::wst_digital)
+            continue;
+
+        sst::waveshapers::QuadWaveshaperState wss{};
+
+        auto wsptr =
+            sst::waveshapers::GetQuadWaveshaper(sst::waveshapers::WaveshaperType::wst_none);
+
+        auto wstype = sst::waveshapers::WaveshaperType(shindex);
+        float drivef alignas(16)[4] = {0.25, 0.5, 1, 1.5};
+
+        INFO("Changing Waveshaper Type to " << sst::waveshapers::wst_names[shindex]);
+        float R alignas(16)[sst::waveshapers::n_waveshaper_registers];
+        initializeWaveshaperRegister(wstype, R);
+        for (int i = 0; i < sst::waveshapers::n_waveshaper_registers; ++i)
+        {
+            wss.R[i] = SIMD_MM(set1_ps)(R[i]);
+        }
+
+        wss.init = SIMD_MM(cmpeq_ps)(SIMD_MM(setzero_ps()), SIMD_MM(setzero_ps()));
+        wsptr = sst::waveshapers::GetQuadWaveshaper(wstype);
+
+        float din alignas(16)[4] = {0, 0, 0, 0};
+        auto dat = SIMD_MM(load_ps)(din);
+        auto drv = SIMD_MM(load_ps)(drivef);
+
+        dat = wsptr(&wss, dat, drv);
+
+        float res alignas(16)[4];
+
+        SIMD_MM(store_ps)(res, dat);
+
+        float rsum{0.f};
+        for (int i = 0; i < 4; ++i)
+            rsum += std::fabs(res[i]);
+        REQUIRE(rsum < 1e-5);
+        if (rsum > 1e-5)
+        {
+            std::cout << sst::waveshapers::wst_names[shindex] << " " << drivef[0] << "->" << res[0]
+                      << " " << drivef[1] << "->" << res[1] << " " << drivef[2] << "->" << res[2]
+                      << " " << drivef[3] << "->" << res[3] << " " << std::endl;
+        }
+    }
+}

--- a/tests/FuzzesTest.cpp
+++ b/tests/FuzzesTest.cpp
@@ -20,16 +20,16 @@ TEST_CASE("Fuzzes Test")
 #else
     SECTION("FUZZ")
     {
-        TestUtils::runTest(
-            {sst::waveshapers::WaveshaperType::wst_fuzz,
-             {0.f, 0.220378f, 0.92792f, 0.927827f, 0.357899f, -0.116849f, -1.00204f, -1.00194f}});
+        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzz,
+                            {0.00000000f, 0.22037821f, 0.92791998f, 0.92782718f, 0.35789865f,
+                             -0.12865001f, -1.00203609f, -1.00193584f}});
     }
 
     SECTION("HEAVY FUZZ")
     {
-        TestUtils::runTest(
-            {sst::waveshapers::WaveshaperType::wst_fuzzheavy,
-             {0.f, 0.261135f, 0.7838f, 0.783722f, 0.0741361f, -0.150006f, -1.00559f, -1.00549f}});
+        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzzheavy,
+                            {0.00000000f, 0.26113454f, 0.78380001f, 0.78372163f, 0.07413614f,
+                             -0.18540987f, -1.00558805f, -1.00548744f}});
     }
 
     SECTION("FUZZ CENTER")
@@ -42,18 +42,18 @@ TEST_CASE("Fuzzes Test")
 
     SECTION("FUZZ SOFT CLIP")
     {
-        TestUtils::runTest(
-            {sst::waveshapers::WaveshaperType::wst_fuzzsoft,
-             {0.f, 0.211718f, 0.763057f, 0.803661f, 0.425659f, -0.117334f, -0.623519f, -0.944568f},
-             5e-2});
+        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzzsoft,
+                            {0.00000000f, 0.22699629f, 0.81701916f, 0.94508040f, 0.46550822f,
+                             -0.02013272f, -0.72161263f, -0.86463588f},
+                            5e-2});
     }
 
     SECTION("FUZZ SOFT EDGE")
     {
-        TestUtils::runTest(
-            {sst::waveshapers::WaveshaperType::wst_fuzzsoftedge,
-             {0.f, 0.16799f, 0.6643f, 0.978468f, 0.395231f, -0.0849648f, -0.748686f, -0.838533f},
-             5e-2});
+        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzzsoftedge,
+                            {0.00000000f, 0.16798960f, 0.66430008f, 0.92657322f, 0.39519930f,
+                             -0.08495888f, -0.74868125f, -0.83852774f},
+                            5e-2});
     }
 #endif
 }

--- a/tests/FuzzesTest.cpp
+++ b/tests/FuzzesTest.cpp
@@ -20,39 +20,39 @@ TEST_CASE("Fuzzes Test")
 #else
     SECTION("FUZZ")
     {
-        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzz,
-                            {0.0113002f, 0.231677f, 0.939218f, 0.939124f, 0.369194f, -0.105554f,
-                             -0.990744f, -0.990645f}});
+        TestUtils::runTest(
+            {sst::waveshapers::WaveshaperType::wst_fuzz,
+             {0.f, 0.220378f, 0.92792f, 0.927827f, 0.357899f, -0.116849f, -1.00204f, -1.00194f}});
     }
 
     SECTION("HEAVY FUZZ")
     {
-        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzzheavy,
-                            {0.0339005f, 0.295032f, 0.817694f, 0.817612f, 0.108023f, -0.116123f,
-                             -0.971712f, -0.971614f}});
+        TestUtils::runTest(
+            {sst::waveshapers::WaveshaperType::wst_fuzzheavy,
+             {0.f, 0.261135f, 0.7838f, 0.783722f, 0.0741361f, -0.150006f, -1.00559f, -1.00549f}});
     }
 
     SECTION("FUZZ CENTER")
     {
-        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzzctr,
-                            {0.392422f, 0.137087f, 0.777535f, 0.983756f, 0.465164f, 0.163438f,
-                             -0.81944f, -0.984097f},
-                            5e-2});
+        TestUtils::runTest(
+            {sst::waveshapers::WaveshaperType::wst_fuzzctr,
+             {0.f, -0.241235f, 0.385376f, 0.591691f, 0.0723392f, -0.231693f, -1.21146f, -1.37649f},
+             5e-2});
     }
 
     SECTION("FUZZ SOFT CLIP")
     {
-        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_fuzzsoft,
-                            {-0.0498637f, 0.176861f, 0.769438f, 0.882686f, 0.411067f, -0.0660712f,
-                             -0.874844f, -0.924149f},
-                            5e-2});
+        TestUtils::runTest(
+            {sst::waveshapers::WaveshaperType::wst_fuzzsoft,
+             {0.f, 0.211718f, 0.763057f, 0.803661f, 0.425659f, -0.117334f, -0.623519f, -0.944568f},
+             5e-2});
     }
 
     SECTION("FUZZ SOFT EDGE")
     {
         TestUtils::runTest(
             {sst::waveshapers::WaveshaperType::wst_fuzzsoftedge,
-             {0.0f, 0.167961f, 0.65832f, 1.00573f, 0.395507f, -0.0849603f, -0.75362f, -0.826739f},
+             {0.f, 0.16799f, 0.6643f, 0.978468f, 0.395231f, -0.0849648f, -0.748686f, -0.838533f},
              5e-2});
     }
 #endif

--- a/tests/HarmonicsTest.cpp
+++ b/tests/HarmonicsTest.cpp
@@ -18,22 +18,30 @@ TEST_CASE("Harmonics Test")
     SECTION("Soft Harmonic 2")
     {
         TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_cheby2,
-                            {-0.983887f, -0.981756f, -0.777578f, 0.983957f, -0.964114f, -0.983526f,
-                             -0.668806f, 0.984113f}});
+                            {
+                                0.f,
+                                0.039981f,
+                                0.777773f,
+                                1.f,
+                                0.244986f,
+                                0.00947075f,
+                                0.85708f,
+                                1.f,
+                            }});
     }
 
     SECTION("Soft Harmonic 3")
     {
         TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_cheby3,
-                            {0.0f, -0.53699f, -0.984323f, 0.984047f, -0.902664f, 0.291438f,
-                             0.98229f, -0.983905f}});
+                            {0.f, -0.536956f, -0.984123f, 0.984142f, -0.902497f, 0.29149f,
+                             0.982302f, -0.984129f}});
     }
 
     SECTION("Soft Harmonic 4")
     {
         TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_cheby4,
-                            {0.983887f, 0.972811f, -0.777908f, 0.984184f, 0.80417f, 0.981804f,
-                             -0.902898f, 0.984195f}});
+                            {0.f, -0.157232f, -0.999996f, 0.000315666f, -0.748524f, -0.0394723f,
+                             -1.f, 0.000751017f}});
     }
 
     SECTION("Soft Harmonic 5")
@@ -46,8 +54,8 @@ TEST_CASE("Harmonics Test")
     SECTION("Additive 1+2")
     {
         TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_add12,
-                            {-0.5f, -0.417053f, 0.135844f, 0.734737f, -0.237945f, -0.528582f,
-                             -0.418359f, -0.154147f}});
+                            {0.f, 0.0829067f, 0.635747f, 1.23454f, 0.261891f, -0.0288343f,
+                             0.0813495f, 0.345475f}});
     }
 
     SECTION("Additive 1+3")
@@ -60,8 +68,8 @@ TEST_CASE("Harmonics Test")
     SECTION("Additive 1+4")
     {
         TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_add14,
-                            {0.5f, 0.497825f, -0.108627f, 0.281226f, 0.292698f, 0.449599f,
-                             -0.771982f, -0.607728f}});
+                            {0.f, -0.0021314f, -0.608528f, -0.218725f, -0.207151f, -0.0501574f,
+                             -1.2717f, -1.10746f}});
     }
 
     SECTION("Additive 1+5")
@@ -81,8 +89,8 @@ TEST_CASE("Harmonics Test")
     SECTION("Additive Saw 3")
     {
         TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_addsaw3,
-                            {-0.257143f, -0.230203f, 0.0978563f, 0.62482f, -0.146698f, -0.263539f,
-                             -0.262559f, -0.326252f}});
+                            {1.49012e-07f, 0.0269183f, 0.35495f, 0.881837f, 0.110362f, -0.00652488f,
+                             -0.00557171f, -0.0692796f}});
     }
 
     SECTION("Additive Square 3")

--- a/tests/RectifiersTest.cpp
+++ b/tests/RectifiersTest.cpp
@@ -35,8 +35,8 @@ TEST_CASE("Rectifiers Test")
 
     SECTION("SOFT RECTIFIER")
     {
-        TestUtils::runTest({sst::waveshapers::WaveshaperType::wst_softrect,
-                            {-0.983887f, -0.969348f, -0.674638f, 0.777768f, 0.465924f, -0.940015f,
-                             -0.674389f, 0.819212f}});
+        TestUtils::runTest(
+            {sst::waveshapers::WaveshaperType::wst_softrect,
+             {0.f, 0.19766f, 0.854048f, 0.999996f, 0.998494f, 0.41006f, 0.853818f, 1.f}});
     }
 }

--- a/tests/ShapesAreBounded.cpp
+++ b/tests/ShapesAreBounded.cpp
@@ -71,6 +71,10 @@ TEST_CASE("All Items are Bounded on Change")
         int shindex = shapertypes[curtypeindex];
         auto wstype = sst::waveshapers::WaveshaperType(shindex);
 
+        if (ssc == 253 && wstype == sst::waveshapers::WaveshaperType::wst_fuzzctr)
+        {
+            std::cout << "Here";
+        }
         dat = wsptr(&wss, dat, drv);
 
         float res alignas(16)[4];
@@ -80,7 +84,9 @@ TEST_CASE("All Items are Bounded on Change")
         if (res[0] < -2.0 || res[0] > 2.0 || std::isnan(res[0]) || std::isinf(res[0]) ||
             res[1] < -2.0 || res[1] > 2.0 || std::isnan(res[1]) || std::isinf(res[1]))
         {
-            INFO("Bad sample produced by waveshaper at " << ssc << " " << res[0] << " " << res[1]);
+            INFO(sst::waveshapers::wst_names[shindex] << " Bad sample produced by waveshaper at "
+                                                      << ssc << " " << din[0] << "->" << res[0]
+                                                      << " " << res[1]);
             REQUIRE(false);
         }
         ssc++;

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <iostream>
+#include <iomanip>
 
 #include <catch2/catch2.hpp>
 #include <sst/waveshapers.h>
@@ -74,8 +75,12 @@ inline void runTest(const TestConfig &config)
     if constexpr (printData)
     {
         std::cout << "{ ";
+        std::string prefix = "";
         for (int i = 0; i < actualData.size(); ++i)
-            std::cout << actualData[i] << "f, ";
+        {
+            std::cout << prefix << std::fixed << std::setprecision(8) << actualData[i] << "f";
+            prefix = ", ";
+        }
 
         std::cout << "}" << std::endl;
     }

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -38,6 +38,9 @@ struct TestConfig
 
 inline void runTest(const TestConfig &config)
 {
+    if (printData)
+        std::cout << sst::waveshapers::wst_names[(int)config.wsType] << std::endl;
+
     QuadWaveshaperState wsState;
     float R[n_waveshaper_registers];
     initializeWaveshaperRegister(config.wsType, R);
@@ -64,6 +67,8 @@ inline void runTest(const TestConfig &config)
 
         if constexpr (!printData)
             REQUIRE(actualData[i] == Approx(config.expectedData[i]).margin(config.margin));
+        else if (actualData[i] != Approx(config.expectedData[i]).margin(config.margin))
+            std::cout << "Mismatch at index " << i << std::endl;
     }
 
     if constexpr (printData)


### PR DESCRIPTION
Some of our shapers didn't map 0->0. Each of those had a DC blocker so that long playing silence didn't produce DC but at onset, the DC blocker hadn't had time to catch up. This change seeds the DC blocker so that at init, the 'prior' value it observes is the input-to-the-blocker for 0, defacto making no click on change at silence.